### PR TITLE
Feature/dialog view model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: node_js
 node_js:
   - '6'
 install:
-  - npm install smild@4.3.8 -g
+  - npm install smild@4.4.0 -g
   - npm install
-  - npm install react react-router react-dom ninjagoat@2.1.0
+  - npm install react react-router react-dom ninjagoat@2.2.0
 script: smild test && smild build
 deploy:
   skip_cleanup: true

--- a/README.md
+++ b/README.md
@@ -90,6 +90,38 @@ if (status === DialogStatus.Confirmed) {
 }
 ```
 
+## ViewModel Dialogs
+If your dialog has some interaction that requires changes to be reflected on both the model and the UI you can use the ModelDialog class, which binds to a special kind of ViewModel named DialogViewModel.
+In order to use it declare your model as a class extending from DialogViewModel, and use it as a standard ViewModel by applying the @Refresh decorator on it.
+
+```typescript
+class MyDialogViewModel extends DialogViewModel {
+    public updates: number = 0;
+     
+    @Refresh
+    public increment() {
+        this.updates++;
+    }
+}
+```
+once defined your ViewModel you can use the ModelDialog class in order to implement your own Dialog view
+
+```typescript
+class MyDialog extends ModelDialog<MyDialogViewModel> {
+
+    render() {
+        let status = this.props.status;
+        let dialog = this.props.dialog;
+        return (
+            <Modal show={dialog.open} onHide={status.cancel.bind(this.props.status)}>
+              <div>{this.viewmodel.updates}</div>
+              <button onClick={() => this.viewmodel.increment()}>Increment</button>
+            </Modal>
+        );
+    }
+}
+```
+
 ## License
 
 Copyright 2016 Tierra SpA

--- a/declarations/ninjagoat-dialogs.d.ts
+++ b/declarations/ninjagoat-dialogs.d.ts
@@ -75,8 +75,8 @@ export abstract class CustomDialog<T> extends React.Component<{dialog: DialogCon
 
 }
 
-export class DialogViewModel<T> implements IViewModel<T> {
-    "force nominal type for IViewModel": T;
+export class DialogViewModel implements IViewModel<void> {
+    "force nominal type for IViewModel": void;
 
     subscribe(observer: IObserver<void>): IDisposable
     subscribe(onNext?: (value: void) => void, onError?: (exception: any) => void, onCompleted?: () => void): Rx.IDisposable;

--- a/declarations/ninjagoat-dialogs.d.ts
+++ b/declarations/ninjagoat-dialogs.d.ts
@@ -1,5 +1,5 @@
 import {IObservable, IObserver, IDisposable} from "rx";
-import {IModule} from "ninjagoat";
+import {IModule, IViewModel} from "ninjagoat";
 import {interfaces} from "inversify";
 import {IViewModelRegistry} from "ninjagoat";
 import {IServiceLocator} from "ninjagoat";
@@ -73,6 +73,15 @@ export class NinjagoatDialog extends React.Component<{templates?: Dictionary<int
 
 export abstract class CustomDialog<T> extends React.Component<{dialog: DialogConfig<T>, status: IStatusUpdate}, any> {
 
+}
+
+export class DialogViewModel<T> implements IViewModel<T> {
+    "force nominal type for IViewModel": T;
+
+    subscribe(observer: IObserver<void>): IDisposable
+    subscribe(onNext?: (value: void) => void, onError?: (exception: any) => void, onCompleted?: () => void): Rx.IDisposable;
+
+    dispose(): void
 }
 
 export interface IStatusUpdate {

--- a/declarations/ninjagoat-dialogs.d.ts
+++ b/declarations/ninjagoat-dialogs.d.ts
@@ -84,6 +84,10 @@ export class DialogViewModel implements IViewModel<void> {
     dispose(): void
 }
 
+export class ModelDialog<T extends DialogViewModel> extends CustomDialog<T> {
+    public viewmodel: T;
+}
+
 export interface IStatusUpdate {
     confirm();
     reject();

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ninjagoat-dialogs",
   "version": "1.1.0",
   "dependencies": {
-    "@types/lodash": "4.14.44",
+    "@types/lodash": "~4.14.44",
     "@types/node": "~6.0.52",
     "@types/react": "~0.14.55",
     "inversify": "~3.0.0-rc.2",

--- a/scripts/components/DialogViewModel.ts
+++ b/scripts/components/DialogViewModel.ts
@@ -3,8 +3,8 @@ import {IViewModel} from "ninjagoat";
 import {injectable} from "inversify";
 
 @injectable()
-class DialogViewModel<T> implements IViewModel<T> {
-    "force nominal type for IViewModel": T;
+class DialogViewModel implements IViewModel<void> {
+    "force nominal type for IViewModel": void;
 
     private subject = new Rx.Subject<void>();
 

--- a/scripts/components/DialogViewModel.ts
+++ b/scripts/components/DialogViewModel.ts
@@ -1,0 +1,37 @@
+import * as Rx from "rx";
+import {IViewModel} from "ninjagoat";
+import {injectable} from "inversify";
+
+@injectable()
+class DialogViewModel<T> implements IViewModel<T> {
+    "force nominal type for IViewModel": T;
+
+    private subject = new Rx.Subject<void>();
+
+    subscribe(observer: Rx.IObserver<void>): Rx.IDisposable
+    subscribe(onNext?: (value: void) => void, onError?: (exception: any) => void, onCompleted?: () => void): Rx.IDisposable
+    subscribe(observerOrOnNext?: (Rx.IObserver<void>) | ((value: void) => void), onError?: (exception: any) => void, onCompleted?: () => void): Rx.IDisposable {
+        if (isObserver(observerOrOnNext))
+            return this.subject.subscribe(observerOrOnNext);
+        else
+            return this.subject.subscribe(observerOrOnNext, onError, onCompleted);
+    }
+
+    protected onError(error: any) {
+        this.subject.onError(error);
+    }
+
+    dispose(): void {
+        this.subject.onCompleted();
+    }
+
+    private notifyChanged() {
+        this.subject.onNext(undefined);
+    }
+}
+
+function isObserver<T>(observerOrOnNext: (Rx.IObserver<T>) | ((value: T) => void)): observerOrOnNext is Rx.IObserver<T> {
+    return (<Rx.IObserver<T>>observerOrOnNext).onNext !== undefined;
+}
+
+export default DialogViewModel;

--- a/scripts/components/ModelDialog.ts
+++ b/scripts/components/ModelDialog.ts
@@ -1,0 +1,25 @@
+import DialogViewModel from "./DialogViewModel";
+import CustomDialog from "./CustomDialog";
+
+export default class ModelDialog<T extends DialogViewModel> extends CustomDialog<T> {
+    public viewmodel: T = this.props.dialog.data;
+
+    componentWillMount() {
+        this.setupPage(this.props);
+    }
+
+    componentWillReceiveProps(props: any) {
+        this.viewmodel.dispose();
+        this.setupPage(props);
+    }
+
+    componentWillUnmount() {
+        if (this.viewmodel) this.viewmodel.dispose();
+    }
+
+    setupPage(props: any) {
+        this.viewmodel = props.dialog.data;
+        this.setState(props.dialog.data);
+        this.viewmodel.subscribe(() => this.setState(this.viewmodel));
+    }
+}

--- a/scripts/components/ModelDialog.ts
+++ b/scripts/components/ModelDialog.ts
@@ -8,11 +8,6 @@ export default class ModelDialog<T extends DialogViewModel> extends CustomDialog
         this.setupPage(this.props);
     }
 
-    componentWillReceiveProps(props: any) {
-        this.viewmodel.dispose();
-        this.setupPage(props);
-    }
-
     componentWillUnmount() {
         if (this.viewmodel) this.viewmodel.dispose();
     }

--- a/scripts/ninjagoat-dialogs.ts
+++ b/scripts/ninjagoat-dialogs.ts
@@ -3,3 +3,5 @@ export {default as NinjagoatDialog} from "./components/NinjagoatDialog";
 export {default as NinjagoatDialogService} from "./components/NinjagoatDialogService";
 export {default as CustomDialog} from "./components/CustomDialog";
 export {default as DialogStatus} from "./DialogStatus";
+export {default as ModelDialog} from "./components/ModelDialog";
+export {default as DialogViewModel} from "./components/DialogViewModel";

--- a/test/DialogViewModelSpec.ts
+++ b/test/DialogViewModelSpec.ts
@@ -1,0 +1,55 @@
+import "reflect-metadata";
+import expect = require("expect.js");
+import * as Rx from "rx";
+import TestDialogViewModel from "./fixtures/TestDialogViewModel";
+
+describe("DialogViewModel, given an instance", () => {
+
+    let subject: TestDialogViewModel;
+    let notifications: void[];
+    let notificationError: any;
+    let notificationsCompleted;
+    let subscription: Rx.IDisposable;
+
+    beforeEach(() => {
+        notifications = [];
+        subject = new TestDialogViewModel();
+        subscription = subject.subscribe(_ => notifications.push(null), error => notificationError = error, () => notificationsCompleted = true);
+    });
+
+    context("when changing the underlying model", () => {
+        it("should notify that a change occurred", () => { 
+            subject.changeSomething();
+
+            expect(notifications).to.not.empty();
+        });
+    });
+
+    context("when triggering an error while changing the underlying model", () => {
+        beforeEach(() => {
+            subject.signalError();
+        });
+
+        it("should notify that an error occurred", () => {
+            expect(notificationError).to.be("error!");
+        });
+
+        it("should not notify that a change occurred", () => {
+            expect(notifications).to.be.empty();
+        });
+    });
+
+    context("when disposing the model", () => {
+        beforeEach(() => {
+            subject.dispose();
+        });
+
+        it("should notify that a completion occurred", () => {
+            expect(notificationsCompleted).to.be.ok();
+        });
+
+        it("should not notify that a change occurred", () => {
+            expect(notifications).to.be.empty();
+        });
+    });
+});

--- a/test/fixtures/TestDialogViewModel.ts
+++ b/test/fixtures/TestDialogViewModel.ts
@@ -1,7 +1,7 @@
 import DialogViewModel from "../../scripts/components/DialogViewModel";
 import {Refresh} from "ninjagoat";
 
-export default class TestDialogViewModel extends DialogViewModel<number> {
+export default class TestDialogViewModel extends DialogViewModel {
     public state: number;
 
     public signalError() { 

--- a/test/fixtures/TestDialogViewModel.ts
+++ b/test/fixtures/TestDialogViewModel.ts
@@ -1,0 +1,15 @@
+import DialogViewModel from "../../scripts/components/DialogViewModel";
+import {Refresh} from "ninjagoat";
+
+export default class TestDialogViewModel extends DialogViewModel<number> {
+    public state: number;
+
+    public signalError() { 
+        this.onError("error!");
+    }
+
+    @Refresh
+    public changeSomething() {
+        this.state = 42;
+    }
+}


### PR DESCRIPTION
This PR introduces support for a DialogViewModel handling refresh like a standard ViewModel but without the need for creating an observable or go through the ViewModelFactory. It also introduces a new ModelDialog class that extends the CustomDialog and introduces refresh.